### PR TITLE
Add plan workflow commands

### DIFF
--- a/.claude/agents/plan-create.md
+++ b/.claude/agents/plan-create.md
@@ -1,0 +1,32 @@
+---
+name: plan-create
+description: Creates a GitHub issue from a saved plan file. Invoked by /plan-create command.
+model: haiku
+permissionMode: acceptEdits
+---
+
+# Create a GitHub issue from the plan
+
+## Task
+
+1. List files in `~/.claude/plans/` sorted by modification time (newest first)
+   - Note: This path must match where plan mode writes files
+2. Read the most recently modified plan file
+3. Extract the title from the plan's main heading
+4. Create the issue:
+   ```bash
+   gh issue create --title "Plan: {title}" --body "{plan content verbatim}"
+   ```
+5. Return the issue URL to confirm completion
+
+## Requirements
+
+- Paste the plan verbatim — do not modify or summarise
+- Title format: `Plan: {title}` where `{title}` comes from the plan heading
+- The `gh` command must be run from within a git repository (current working directory assumption)
+
+## Error handling
+
+- If no plan files found in `~/.claude/plans/`, report this clearly and stop
+- If issue creation fails, report the error
+- If there are permission issues with GitHub, report them

--- a/.claude/commands/plan-create.md
+++ b/.claude/commands/plan-create.md
@@ -1,0 +1,25 @@
+# Create a GitHub issue from the plan
+
+## Usage
+
+- `/plan-create` - Creates an issue from the most recent plan in `~/.claude/plans/`
+
+## Context
+
+This creates a GitHub issue with the plan as the issue description. The issue becomes the single source of truth for subsequent sessions. After creating the issue, run `/plan-prompt` with the issue number to post the revised prompt as the first comment.
+
+## Task
+
+1. Spawn a `plan-create` subagent using the Task tool with `subagent_type: "plan-create"`
+2. Return the issue URL from the subagent's response
+3. Remind the user to run `/plan-prompt <issue>` to save the revised prompt
+
+## Requirements
+
+- Delegate immediately — do not attempt to read the plan yourself
+
+## Error handling
+
+- If the subagent reports no plan found, ask the user to confirm a plan exists in `~/.claude/plans/`
+- If issue creation fails, report the error from the subagent
+- If there are permission issues with GitHub, report them

--- a/.claude/commands/plan-handoff.md
+++ b/.claude/commands/plan-handoff.md
@@ -1,0 +1,38 @@
+# Post a technical handoff comment to a GitHub issue
+
+## Usage
+
+- `/plan-handoff` - Uses the issue number from conversation context
+- `/plan-handoff <issue>` - Posts to the specified issue (e.g., `85`)
+
+## Context
+
+The handoff responds to the plan. The plan defines "what we will do"; the handoff documents "what we actually did". Future sessions use `/plan-resume` to load this context.
+
+## Task
+
+1. Identify the issue number from the argument or search the conversation for a GitHub issue URL or number. If not found, report this and stop.
+2. Synthesise implementation details from the conversation
+3. Format and post the handoff comment using `gh issue comment <issue> --body "..."`
+4. Return the comment URL to confirm completion
+
+## Handoff content
+
+Focus on technical specifics not obvious from the code:
+
+1. **Implementation notes** - Deviations from plan, technical decisions, patterns used
+2. **Gotchas** - Import paths, type quirks, environment setup, test mocks required
+3. **Verification** - Commands to run tests and lint checks with correct filters
+4. **Limitations** - Known constraints, edge cases, incomplete aspects
+
+## Requirements
+
+- Focus on information a future agent needs that isn't visible in the diff
+- Include runnable commands with correct package/path filters
+- Keep it concise - avoid repeating what's in the plan or PR description
+
+## Error handling
+
+- If issue number cannot be determined, report this clearly and stop
+- If issue does not exist, report the error
+- If there are permission issues, report them

--- a/.claude/commands/plan-prompt.md
+++ b/.claude/commands/plan-prompt.md
@@ -1,0 +1,56 @@
+# Synthesise a revised prompt from the conversation
+
+## Usage
+
+- `/plan-prompt` - Displays the revised prompt in the conversation
+- `/plan-prompt <issue>` - Posts the revised prompt as a comment to the specified issue (e.g., `85`)
+
+## Context
+
+Use this at the end of a planning session to capture a refined, reusable prompt. The conversation often clarifies requirements, resolves ambiguities, and surfaces concrete examples — this command distils that into a prompt suitable for future use or similar tasks.
+
+When an issue number is provided, the prompt is posted as the first comment on the issue. This preserves the original requirements alongside the plan for future reference.
+
+## Task
+
+### Print the original prompt
+
+Print the user's original prompt verbatim. This must happen first to anchor the rephrasing.
+
+### Synthesise a revised prompt
+
+**Include:**
+- Clarifications received during the conversation
+- Data structures and schemas (show concrete examples, not placeholders)
+- Files to modify and validation steps
+
+**Improve:**
+- Logical order and flow
+- Clarity and conciseness
+
+**Remove:**
+- Rejected alternatives and their analysis
+- Redundant examples that convey the same information
+- Exploratory questions already answered
+
+### Print the revised prompt
+
+Present the revised prompt in a copyable format.
+
+### Post to issue (if issue number provided)
+
+Post the revised prompt as a comment using `gh issue comment <issue> --body "..."` and return the comment URL to confirm.
+
+## Requirements
+
+- Preserve technical accuracy
+- Aim for clarity over brevity
+- Present the revised prompt in a copyable format
+- When posting to an issue, use a clear header (e.g., "## Revised Prompt")
+
+## Error handling
+
+- If there is no discernible original prompt in the conversation, report this and stop
+- If issue number cannot be determined, report this clearly and stop
+- If issue does not exist, report the error
+- If there are permission issues, report them

--- a/.claude/commands/plan-resume.md
+++ b/.claude/commands/plan-resume.md
@@ -1,0 +1,34 @@
+# Load context from a GitHub issue
+
+## Usage
+
+- `/plan-resume` - Uses the issue number from conversation context
+- `/plan-resume <issue>` - Loads context from the specified issue (e.g., `85`)
+
+## Context
+
+Use this to continue work started in a previous session. The issue contains the plan (description) and any handoff comments documenting progress. After completing work, use `/plan-handoff` to document the session.
+
+## Task
+
+1. Identify the issue number from the argument or search the conversation for a GitHub issue URL or number. If not found, report this and stop.
+2. Fetch all data in a single call:
+   ```bash
+   gh issue view <issue> --json title,body,state,createdAt,comments
+   ```
+3. Present the data in this order:
+   - Issue title and state
+   - Issue body (the plan)
+   - Comments in chronological order (revised prompt, handoffs, discussion)
+4. Summarise the current state and ask how to proceed
+
+## Requirements
+
+- This is read-only — do not modify the issue
+- For each comment: include author, timestamp, and full body
+
+## Error handling
+
+- If issue number cannot be determined, report this clearly and stop
+- If issue does not exist, report the error
+- If there are permission issues, report them

--- a/.claude/commands/plan-update.md
+++ b/.claude/commands/plan-update.md
@@ -1,0 +1,45 @@
+# Update a GitHub issue with revised plan
+
+## Usage
+
+- `/plan-update` - Uses the issue number from conversation context
+- `/plan-update <issue>` - Updates the specified issue (e.g., `85`)
+
+## Context
+
+Use this after `/plan-validate` when validation reveals significant gaps or inaccuracies that require plan revision. The GitHub issue remains the single source of truth — this command pushes conversation refinements back to the issue.
+
+## Task
+
+1. Identify the issue number from the argument or search the conversation for a GitHub issue URL or number. If not found, report this and stop.
+2. Fetch the current issue to get the existing title and body:
+   ```bash
+   gh issue view <issue> --json title,body
+   ```
+3. Synthesise the revised plan from the conversation:
+   - Incorporate feedback from validation
+   - Address identified gaps and inaccuracies
+   - Preserve the original structure where unchanged
+4. Present the revised plan to the user for approval before updating
+5. Once approved, update the issue:
+   ```bash
+   gh issue edit <issue> --body "$(cat <<'EOF'
+   ...revised plan content...
+   EOF
+   )"
+   ```
+6. Confirm the update with the issue URL
+
+## Requirements
+
+- Requires user approval before updating — always show the diff or full revised content first
+- Preserve formatting and structure from the original plan
+- Only modify sections that need revision based on the conversation
+- Do not change the issue title unless explicitly discussed
+
+## Error handling
+
+- If issue number cannot be determined, report this clearly and stop
+- If no revisions were discussed in the conversation, report this and stop
+- If issue does not exist, report the error
+- If there are permission issues, report them

--- a/.claude/commands/plan-validate.md
+++ b/.claude/commands/plan-validate.md
@@ -1,0 +1,45 @@
+# Validate a plan before implementation
+
+## Usage
+
+- `/plan-validate` - Uses the issue number from conversation context
+- `/plan-validate <issue>` - Validates the plan from the specified issue (e.g., `85`)
+
+## Context
+
+Use this in session 2 after loading the plan with `/plan-resume`. A fresh session provides perspective that the planning session lacks — assumptions become visible, gaps surface, and ambiguities clarify. This step catches issues before code is written.
+
+## Task
+
+1. Identify the issue number from the argument or search the conversation for a GitHub issue URL or number. If not found, report this and stop.
+2. If the plan was already loaded via `/plan-resume`, use the existing context. Otherwise, fetch the issue:
+   ```bash
+   gh issue view <issue> --json title,body,state
+   ```
+3. Review the plan against these criteria:
+   - **Clarity** — Are the steps unambiguous? Could another agent implement this without guessing?
+   - **Accuracy** — Do referenced files, functions, and patterns actually exist? Verify with codebase exploration.
+   - **Completeness** — Are edge cases addressed? Are dependencies identified? Is the scope well-bounded?
+   - **Feasibility** — Can this be implemented with the current architecture? Are there hidden complexities?
+4. Collect additional information:
+   - Explore the codebase to verify assumptions made in the plan
+   - Check that referenced files and patterns exist as described
+   - Identify related code that might be affected
+5. Present findings:
+   - List any gaps, inaccuracies, or ambiguities found
+   - Note verification results (what exists, what doesn't)
+   - Ask clarifying questions for items that need user input
+6. If the plan is sound, confirm readiness to proceed with implementation
+
+## Requirements
+
+- This is read-only — do not modify the issue
+- Verify claims against the actual codebase, not assumptions
+- Ask focused questions rather than presenting long lists of possibilities
+- Be direct about problems — vague concerns waste time
+
+## Error handling
+
+- If issue number cannot be determined, report this clearly and stop
+- If issue does not exist, report the error
+- If there are permission issues, report them

--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -1,0 +1,37 @@
+# Slash commands
+
+Commands must be invoked explicitly; they do not run automatically.
+
+## Architecture
+
+Commands live in `.claude/commands/`. Most commands execute directly. Commands that don't require conversation context may delegate to subagents.
+
+**Subagent limitation:** Subagents start with a clear context — they cannot access the parent conversation. Only delegate to subagents when the command reads from files or APIs rather than conversation history.
+
+**Subagent pattern:**
+- Command file (`.claude/commands/{name}.md`) — invocation instructions, spawns subagent
+- Agent file (`.claude/agents/{name}.md`) — task instructions for the subagent
+
+## Plan workflow
+
+**/plan-create** — creates a GitHub issue with the plan as description (uses subagent)
+
+**/plan-prompt** — saves a revised prompt as a comment to the issue
+
+**/plan-resume** — loads plan and handoffs from an issue to continue work
+
+**/plan-validate** — validates a plan for clarity, accuracy and completeness before implementation
+
+**/plan-update** — updates a GitHub issue with revised plan content from the conversation
+
+**/plan-handoff** — posts a technical handoff comment synthesising implementation from the conversation
+
+## Pull requests
+
+**/pr-create** — creates a GitHub pull request from current branch commits
+
+**/pr-response** — responds to PR review comments based on work done in the conversation
+
+**/pr-fetch-all-comments** — fetches all PR comments including inline review comments
+
+**/pr-fetch-only-comments** — fetches review and issue comments only (no inline)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# Plan workflow
+
+Multi-session workflow for planning, validating, and implementing features.
+
+## Source of truth
+
+- **Session 1:** Local plan file (`~/.claude/plans/`)
+- **Sessions 2+:** GitHub issue
+
+Once the plan is published to GitHub, the issue becomes the single source of truth. Avoid entering plan mode in subsequent sessions — this creates duplicate local files that diverge from the issue.
+
+## Session 1: Create
+
+Design the implementation and publish the plan.
+
+1. Enter plan mode to explore the codebase and design the approach
+2. Claude writes the plan to `~/.claude/plans/`
+3. `/plan-create` — publishes the plan to a new GitHub issue
+4. `/plan-prompt <issue>` — posts the revised prompt as the first comment
+5. Keep the session open; validation resumes in a new session for fresh perspective
+
+**Issue structure:**
+- Description: Plan (living document, updated via `/plan-update`)
+- First comment: Revised prompt (static snapshot of refined requirements)
+
+## Session 2: Validate
+
+Review the plan with fresh context. A new session helps identify gaps and assumptions that were invisible during planning.
+
+1. `/plan-resume <issue>` — loads the plan from GitHub
+2. `/plan-validate` — checks clarity, accuracy, and completeness against the codebase
+3. `/plan-update` — pushes any revisions back to the issue (if needed)
+4. Continue to implementation, or close and resume later
+
+## Session 3: Implement
+
+Execute the plan and document the work.
+
+1. `/plan-resume <issue>` — skip if continuing from session 2
+2. Implement the plan
+3. `/plan-handoff` — documents what was done as an issue comment
+4. `/pr-create` — creates a pull request
+
+## Session 4: Code review
+
+Respond to PR feedback after review.
+
+1. `/plan-resume <issue>` — loads context from the plan
+2. Read the PR description (manual) — recall scope and decisions
+3. `/pr-fetch-all-comments` — fetches review comments including inline feedback
+4. List issues to address from the review (manual)
+5. Implement fixes
+6. `/pr-response` — posts a summary of changes made in response to review
+
+## Iteration
+
+For complex features spanning multiple sessions:
+
+- End each session with `/plan-handoff` to document progress
+- Start the next session with `/plan-resume` to load full context
+- Handoff comments accumulate chronologically, preserving session history
+
+See `.claude/rules/commands.md` for the full command reference.


### PR DESCRIPTION
## Overview

Adds a multi-session workflow for planning, validating, and implementing features using GitHub issues as the source of truth.

## Technical details

**New commands:**
- `/plan-create` — creates a GitHub issue from a local plan file (delegates to subagent)
- `/plan-prompt` — posts the revised prompt as a comment to the issue
- `/plan-resume` — loads plan and handoff context from an issue
- `/plan-validate` — validates plan clarity, accuracy, and completeness against the codebase
- `/plan-update` — pushes revised plan content back to the issue
- `/plan-handoff` — documents implementation progress as an issue comment

**Supporting files:**
- `.claude/agents/plan-create.md` — subagent instructions for issue creation
- `.claude/rules/commands.md` — command reference documentation
- `README.md` — workflow documentation

**Workflow design:**
- Session 1: Plan locally, publish to GitHub issue, capture revised prompt
- Session 2: Resume from issue, validate plan, update if needed
- Session 3+: Implement, document handoffs, create PR

## Plan reference

Linked plan: N/A (this PR establishes the workflow itself)