### PR TITLE
Fix statusline context percentage calculation

### DIFF
--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -2,13 +2,8 @@
 input=$(cat)
 
 eval "$(echo "$input" | jq -r '
-  "MODEL=\"\(.model.display_name // "Unknown")\"",
-  "INPUT_TOKENS=\(.context_window.total_input_tokens // 0)",
-  "OUTPUT_TOKENS=\(.context_window.total_output_tokens // 0)",
-  "CONTEXT_SIZE=\(.context_window.context_window_size // 0)"
+  "MODEL=\"\(.model.display_name // \"Unknown\")\"",
+  "CONTEXT_PCT=\(.context_window.used_percentage // 0 | floor)"
 ')"
-
-TOTAL_TOKENS=$((INPUT_TOKENS + OUTPUT_TOKENS))
-CONTEXT_PCT=$((CONTEXT_SIZE > 0 ? TOTAL_TOKENS * 100 / CONTEXT_SIZE : 0))
 
 echo "$MODEL | Context ${CONTEXT_PCT}%"


### PR DESCRIPTION
## Overview

Fix incorrect context percentage in statusline by using the pre-calculated `used_percentage` field instead of computing from cumulative token totals.

## Technical details

The previous calculation summed `total_input_tokens + total_output_tokens` and divided by `context_window_size`. This produced incorrect values because these are cumulative session totals, not current context window usage.

The fix uses `context_window.used_percentage` directly, which matches the value shown by `/context`. The `| floor` in jq ensures an integer value for display.

## Plan reference

Linked plan: #5