### PR TITLE
Fix jq string quoting regression in statusline

### DIFF
--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -2,7 +2,7 @@
 input=$(cat)
 
 eval "$(echo "$input" | jq -r '
-  "MODEL=\"\(.model.display_name // \"Unknown\")\"",
+  "MODEL=\"\(.model.display_name // "Unknown")\"",
   "CONTEXT_PCT=\(.context_window.used_percentage // 0 | floor)"
 ')"
 


### PR DESCRIPTION
## Overview

Fix regression introduced in PR #6 where incorrect quote escaping broke the statusline script.

## Technical details

The previous fix escaped inner quotes as `// \"Unknown\"` based on a review suggestion. This was incorrect because the jq expression is wrapped in single quotes — inside single-quoted bash strings, backslashes are literal characters, not escape sequences.

The escaped version passed invalid syntax to jq, causing the statusline to display `| Context %` (empty values). This reverts to the correct form `// "Unknown"`.

## Plan reference

Linked plan: #5

Related: #6