### PR TITLE
Add /team-code-review command

### DIFF
--- a/.claude/commands/plan-validate.md
+++ b/.claude/commands/plan-validate.md
@@ -45,18 +45,16 @@ Output the structured report between `---` separators. This is the last text you
 ```
 ---
 
+# Instructions
+
+1. Enter plan mode and address the findings below
+2. Resolve each item and update the plan
+3. Exit plan mode
+4. Run `/plan-update` to push the revised plan to the GitHub issue
+
+Do not proceed with implementation yet.
+
 # Plan validation report
-
-## Instruction
-
-Enter plan mode and address the findings below. Update the plan to
-resolve each item. Once done, exit plan mode and run `/plan-update` to
-push the revised plan to the GitHub issue.
-
-Do not proceed with implementation until the plan is updated.
-
-If the report identifies no issues requiring plan changes, you may skip
-the update and proceed directly with implementation.
 
 ## Findings
 
@@ -69,10 +67,22 @@ the update and proceed directly with implementation.
 ---
 ```
 
-After outputting the report, copy the full report (between and including the `---` separators) to the system clipboard. Check the platform using `uname -s` and use the appropriate command silently via Bash:
-- **Windows/MINGW/MSYS**: `clip`
-- **Darwin**: `pbcopy`
-- **Linux**: `xclip -selection clipboard`, falling back to `xsel -b` if `xclip` is unavailable
+After outputting the report, copy everything between and including the `---` separators to the system clipboard. 
+
+Detect the platform and run the appropriate command silently via Bash:
+
+```bash
+OS=$(uname -s)
+case "$OS" in
+  MINGW*|MSYS*|CYGWIN*) cat <<'EOF' | clip ;;
+  Darwin)                cat <<'EOF' | pbcopy ;;
+  Linux)                 cat <<'EOF' | xclip -selection clipboard 2>/dev/null || cat <<'EOF' | xsel -b ;;
+esac
+<paste the report text here>
+EOF
+```
+
+Replace `<paste the report text here>` with the full report text. The heredoc preserves formatting and special characters.
 
 ## Constraints
 

--- a/.claude/commands/team-code-review.md
+++ b/.claude/commands/team-code-review.md
@@ -1,0 +1,133 @@
+# Run a pre-PR team code review
+
+## Usage
+
+- `/team-code-review` or `/team-code-review local` -> current branch vs default branch
+- `/team-code-review <PR_URL>` -> e.g., `https://github.com/owner/repo/pull/263`
+- `/team-code-review <number>` -> assumes PR in current repo
+- `/team-code-review origin/<branch>` -> remote branch vs default branch
+- `/team-code-review <branch>` -> local branch vs default branch
+- Text after the first parameter is passed to all reviewers as additional instructions
+
+## Context
+
+Use this before creating a pull request. It sits between `/plan-handoff` and `/pr-create` in the plan workflow and can also be used standalone for any branch or PR. Intended for non-trivial changes — trivial fixes do not warrant four reviewers.
+
+## Task
+
+Six phases executed in order.
+
+### Phase 1 — Resolve scope
+
+Determine the default branch:
+
+```bash
+gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
+```
+
+Parse the first parameter to determine the diff source. Evaluate rules in the order listed; first match wins.
+
+- **PR URL** — extract owner, repo, and number via regex `https://github.com/([^/]+)/([^/]+)/pull/(\d+)`; fetch with `gh pr diff <number> --repo <owner>/<repo>`
+- **Numeric** — treat as PR number in current repo; fetch with `gh pr diff <number>`
+- **Starts with `origin/`** — treat as remote ref; run `git fetch origin` then `git diff <default>...<value>`
+- **Empty or `local`** — current branch; `git diff <default>...HEAD`. The keyword `local` is consumed as the scope token, not forwarded as instructions.
+- **Other string** — treat as local branch name, including branches containing `/` (e.g., `feature/login`); `git diff <default>...<branch>`
+
+Everything after the first whitespace-delimited token is passed to reviewers as additional instructions.
+
+### Phase 2 — Collect metadata
+
+Gather:
+
+- Changed file list: `git diff <default>...<branch> --name-only` (or `gh pr diff <number> --name-only` for PRs)
+- Commit messages: `git log --oneline -10 <default>..<branch>` (or `gh pr view <number> --json commits` for PRs)
+
+If the diff is empty, report "No changes detected" and stop.
+
+Read all changed files in full so reviewers have complete file context beyond the diff hunks. If more than 20 files changed, skip full file reads and provide the diff only — note this for reviewers.
+
+If the diff exceeds 2000 lines, keep the first 2000 lines and discard the rest. Note the omission and list truncated or excluded files.
+
+### Phase 3 — Create review team
+
+Create the team with a unique name by appending a short random suffix (e.g., `code-review-a3f9`) via `TeamCreate`. Spawn four reviewers via the Task tool (`subagent_type: "general-purpose"`, `model: "sonnet"`), passing the team name. Each reviewer receives the diff, file list, commit context, and any additional instructions.
+
+Three reviewers receive specialisations chosen by the system based on the code under review. The fourth is the **sceptic** — it challenges assumptions, questions necessity, identifies what the other reviewers missed, and suggests simpler alternatives.
+
+Each reviewer outputs findings as a bulleted list. Each finding includes: severity (Critical/High/Medium/Low), file path, line reference where applicable, description, and suggestion.
+
+### Phase 4 — Collect reviews
+
+Wait for all four reviewers to respond via the team messaging system. If a reviewer fails or does not respond within the platform's default task timeout, proceed with available reviews and note the missing reviewer in the report.
+
+### Phase 5 — Generate report
+
+Consolidate findings into a structured report between `---` separators:
+
+```
+---
+
+# Team code review report
+
+## Review scope
+
+Source: [description]
+Files changed: [count]
+
+## [Reviewer 1 — system-assigned focus]
+
+[findings or "No issues identified"]
+
+## [Reviewer 2 — system-assigned focus]
+
+[findings or "No issues identified"]
+
+## [Reviewer 3 — system-assigned focus]
+
+[findings or "No issues identified"]
+
+## Sceptic
+
+[critical perspective or "No concerns"]
+
+## Summary
+
+Total: [count by severity]
+Recommendation: [Proceed to PR / Address findings first]
+
+---
+```
+
+Copy the report to the system clipboard silently. Detect the platform and run the appropriate command via Bash:
+
+```bash
+OS=$(uname -s)
+case "$OS" in
+  MINGW*|MSYS*|CYGWIN*) cat <<'EOF' | clip ;;
+  Darwin)                cat <<'EOF' | pbcopy ;;
+  Linux)                 cat <<'EOF' | xclip -selection clipboard 2>/dev/null || cat <<'EOF' | xsel -b ;;
+esac
+<paste the report text here>
+EOF
+```
+
+Replace `<paste the report text here>` with the full report text. The heredoc preserves formatting and special characters.
+
+### Phase 6 — Cleanup
+
+Send `shutdown_request` to all reviewers. Wait briefly for acknowledgements, then proceed to `TeamDelete` — do not block indefinitely on unresponsive reviewers.
+
+## Constraints
+
+- Do not ask follow-up questions after the report ("Should we proceed?", "What would you like to do next?")
+- The report is the absolute last text output
+- The clipboard command runs silently — no output after the report
+
+## Error handling
+
+- If the PR URL format is invalid, report the expected format and stop
+- If the PR is not found, report the error and stop
+- If the branch is not found, report the error and stop
+- If the diff is empty, report "No changes detected" and stop
+- If `git fetch` fails (e.g., network issues), report the error and stop
+- If there are permission issues, report them

--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -18,11 +18,15 @@ Commands live in `.claude/commands/`. Most commands execute directly. Commands t
 
 **/plan-read** — loads plan and handoffs from an issue to continue work
 
-**/plan-validate** — loads the plan (chains `/plan-read`), validates against the codebase, interviews the engineer if needed, and outputs a structured report for the planning agent
+**/plan-validate** — loads the plan (invokes `/plan-read`), validates against the codebase, interviews the engineer if needed, and outputs a structured report for the planning agent
 
 **/plan-update** — updates a GitHub issue with revised plan content from the conversation
 
 **/plan-handoff** — posts a technical handoff comment synthesising implementation from the conversation
+
+## Code review
+
+**/team-code-review** — spawns a review team (three system-assigned reviewers plus a sceptic) to analyse changes before PR creation
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,13 @@ Execute the plan and document the work.
 1. `/plan-read <issue>` — loads the plan and any handoff comments from prior sessions
 2. Implement the plan
 3. `/plan-handoff` — documents what was done as an issue comment, capturing decisions, gotchas, and verification steps not obvious from the diff
-4. `/pr-create` — creates a pull request from the current branch
+4. `/team-code-review` — runs a pre-PR team review with four specialised reviewers
+5. Address critical and high-severity findings before proceeding
+6. `/pr-create` — creates a pull request from the current branch
+
+## Team review
+
+Pre-PR code review intended for non-trivial changes. The report is copied to the clipboard for reference. See step 4 of the Implement section above.
 
 ## Review
 


### PR DESCRIPTION
## Overview

Adds a `/team-code-review` command that spawns four code reviewers (three with system-assigned specialisations, one sceptic) to analyse a diff before PR creation. Sits between `/plan-handoff` and `/pr-create` in the plan workflow.

Also refactors the `/plan-validate` report template: instructions are now a numbered list under a separate H1 heading above the report, making the exit-plan-mode and `/plan-update` steps explicit. Clipboard code blocks use `$REPORT` variable instead of pseudocode `cat report`.

## Technical details

- New file: `.claude/commands/team-code-review.md` — six-phase command (resolve scope, collect metadata, create review team, collect reviews, generate report, cleanup)
- Modified: `.claude/commands/plan-validate.md` — restructured report template, clipboard code block
- Modified: `.claude/rules/commands.md` — added Code review section
- Modified: `README.md` — added step 4 `/team-code-review` and step 5 "address findings" to Implement section, added Team review section

## Plan reference

Linked plan: #10