### PR TITLE
Add plan-implement and run-interview commands

### DIFF
--- a/.claude/commands/agent-pre-planner.md
+++ b/.claude/commands/agent-pre-planner.md
@@ -101,7 +101,7 @@ The result reads as if the user had written the brief with full knowledge of the
 
 If the scope is large enough to warrant multiple implementation stages, include a workload split as the final part of the enhanced brief. Evaluate scope by considering: the number of distinct subsystems affected, the depth of the dependency chain between tasks, and whether intermediate validation gates exist.
 
-When splitting is warranted, list each plan with a short title, its constituent tasks, dependencies on prior plans, and a validation gate (how to verify that plan's work before proceeding). Order plans by dependency — earlier plans must not depend on later ones. When the scope is narrow, state that a single plan is sufficient and skip the split.
+When splitting is warranted, list each plan with a short title, its constituent tasks, dependencies on prior plans, and a validation gate (how to verify that plan's work before proceeding). Order plans by dependency — earlier plans must not depend on later ones. When the scope is narrow, state that a single plan is sufficient.
 
 Output the report:
 
@@ -128,10 +128,11 @@ The result is the user's brief as it would read with full knowledge of the codeb
 [Questions that require user input before planning -- grouped by priority (blocking first,
 then deferrable). One per line. Full context in § Question below.]
 
-### Workload split [omit if single plan suffices]
+### Workload split
 
 [Scope assessment: brief justification for splitting or not. When splitting,
-list each plan with title, tasks, dependency on prior plans, and validation gate.]
+list each plan with title, tasks, dependency on prior plans, and validation gate.
+When not splitting, state that a single plan is sufficient.]
 
 ## Findings
 
@@ -168,8 +169,6 @@ note these separately.]
 ```
 
 ### Phase 6 — Save report
-
-#### Save report
 
 Write the report to `.claude/reports/pre-plan-{date}-{id}.md`, where `{date}` is the current date in `YYYY-MM-DD` format and `{id}` is the same random suffix used for the team name (e.g., `pre-plan-2026-02-16-a3f9.md`).
 Create the `.claude/reports/` directory if it does not exist.

--- a/.claude/commands/plan-implement.md
+++ b/.claude/commands/plan-implement.md
@@ -1,0 +1,32 @@
+# Implement a plan from a GitHub issue
+
+## Usage
+
+- `/plan-implement` — uses the issue number from conversation context
+- `/plan-implement <issue>` — implements the plan from the specified issue (e.g., `85`)
+
+## Context
+
+Run this after the plan has been created (`/plan-create`) and optionally validated (`/plan-validate`). The issue description contains the plan; comments may contain handoffs from prior sessions.
+
+## Task
+
+1. Load the plan by invoking `/plan-read` via the Skill tool (use `skill: "plan-read"` and pass the issue number as `args` if provided).
+2. Parse the plan into discrete, ordered work items.
+3. Implement each work item sequentially:
+   - Make the changes.
+   - If the repository has a build or test step, verify the changes compile and pass relevant tests.
+   - Report progress before moving to the next item.
+4. Summarise what was implemented and note any items skipped or deferred.
+
+## Requirements
+
+- Follow the plan as written. Do not make unrelated changes.
+- Do not commit to Git — leave changes for user review.
+- If an item is ambiguous or appears incorrect, use the `AskUserQuestion` tool to clarify before proceeding.
+- If a work item fails (does not compile, breaks tests), report the failure and ask how to proceed rather than guessing a fix.
+
+## Error handling
+
+- If the issue number cannot be determined, report this and stop.
+- If the issue does not exist or is inaccessible, report the error.

--- a/.claude/commands/run-interview.md
+++ b/.claude/commands/run-interview.md
@@ -1,0 +1,1 @@
+Use the `AskUserQuestion` tool to present open questions interactively.

--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -22,6 +22,8 @@ Commands live in `.claude/commands/`. Most commands execute directly. Commands t
 
 **/plan-update** — updates a GitHub issue with revised plan content from the conversation
 
+**/plan-implement** — loads a plan from a GitHub issue and implements it sequentially, one work item at a time
+
 **/plan-handoff** — posts a technical handoff comment synthesising implementation from the conversation
 
 ## Pre-plan analysis


### PR DESCRIPTION
## Overview

Add two new slash commands (`/plan-implement`, `/run-interview`) and clean up the pre-planner report template.

## Technical details

- **`plan-implement.md`** (new): Structured command that loads a plan from a GitHub issue via `/plan-read`, parses it into ordered work items, and implements them sequentially with verification between steps. Follows the same section layout as `plan-read` (Usage, Context, Task, Requirements, Error handling).
- **`run-interview.md`** (new): Single-line command that delegates to `AskUserQuestion` for interactive clarification.
- **`agent-pre-planner.md`** (cleanup): Workload split section is now always present in the report template (with guidance to state "single plan" when splitting is not warranted). Removed redundant `#### Save report` subheading. Removed trailing "skip the split" phrasing.

## Plan reference

Linked plan: N/A