### PR TITLE
Sync agent commands

### DIFF
--- a/.claude/commands/agent-code-review.md
+++ b/.claude/commands/agent-code-review.md
@@ -2,14 +2,13 @@
 
 ## Usage
 
-- `/agent-code-review` -> current branch vs default branch
-- `/agent-code-review <PR_URL>` -> e.g., `https://github.com/owner/repo/pull/263`
-- `/agent-code-review pr <number>` -> PR in current repo
-- `/agent-code-review origin/<branch>` -> remote branch vs default branch
-- `/agent-code-review commit <sha>` -> single commit diff (SHA must be at least 7 characters)
-- `/agent-code-review <branch>` -> local branch vs default branch
-- `/agent-code-review directory <path>` -> all files in the specified directory
-- Text after the scope parameters is passed to all reviewers as additional instructions
+- `/agent-code-review` — current branch vs default branch
+- `/agent-code-review pr <number|URL>` — PR by number (current repo) or full URL
+- `/agent-code-review origin/<branch>` — remote branch vs default branch
+- `/agent-code-review branch <name>` — local branch vs default branch
+- `/agent-code-review commit <sha>` — single commit diff (SHA must be at least 7 characters)
+- `/agent-code-review directory <path>` — all files in the specified directory
+- Text after the scope parameters is passed as additional instructions
 
 ## Context
 
@@ -18,7 +17,7 @@ Best suited to non-trivial changes; trivial fixes do not warrant a full agent re
 
 ## Task
 
-Six phases executed in order.
+Eight phases executed in order.
 
 ### Phase 1 — Resolve scope
 
@@ -31,84 +30,60 @@ gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
 Parse the first parameter to determine the review source. Evaluate rules in the order listed; first match wins.
 
 - **Empty** — current branch; `git diff <default>...HEAD`
-- **PR URL** — extract owner, repo, and number via regex `https://github.com/([^/]+)/([^/]+)/pull/(\d+)`; fetch with `gh pr diff <number> --repo <owner>/<repo>`
-- **`pr`** — second token is the PR number; fetch with `gh pr diff <number>`
+- **`pr`** — second token is either a PR number or a full URL. If numeric, fetch with `gh pr diff <number>`. If URL, extract owner, repo, and number via regex `https://github.com/([^/]+)/([^/]+)/pull/(\d+)` and fetch with `gh pr diff <number> --repo <owner>/<repo>`.
 - **Starts with `origin/`** — treat as remote ref; run `git fetch origin` then `git diff <default>...<value>`
+- **`branch`** — second token is the local branch name; `git diff <default>...<branch>`
 - **`commit`** — second token is the SHA; `git show <sha>`
-- **Bare SHA** — 7–40 hex characters; `git show <sha>`. Note: a branch name composed entirely of hex characters (e.g. `abc1234`) will be treated as a SHA. Use `git diff` directly in that case.
 - **`directory`** — second token is the directory path; read all files in that directory recursively
-- **Other string** — treat as local branch name, including branches containing `/` (e.g., `feature/login`); `git diff <default>...<branch>`
+- **Other string** — use `AskUserQuestion` to clarify the intended scope. Present the input value and suggest the available keyword forms (`pr`, `branch`, `commit`, `directory`, `origin/`). Proceed based on the user's response.
 
-For `pr`, `commit`, and `directory`, both tokens (keyword and value) are consumed as scope and not forwarded as instructions; everything after the second token is passed as additional instructions. For all other sources, everything after the first token is passed as additional instructions.
+Keyword sources (`pr`, `branch`, `commit`, `directory`) consume two tokens; remaining tokens are additional instructions.
+All other sources consume one token or none; remaining tokens are additional instructions.
 
-Note: `pr`, `commit`, and `directory` are reserved keywords. A branch with one of these names cannot be reviewed using the bare branch form — use `git diff` directly in that case.
+Use the resolved ref for all git commands in subsequent phases (e.g., `origin/feature-branch` for remote branches).
+
+`pr`, `branch`, `commit`, and `directory` are reserved — to review a branch named "commit", use `branch commit`.
 
 ### Phase 2 — Collect metadata
 
-For a **`commit` keyword or bare SHA** source, all diff and file data comes from `git show <sha>`. Skip the branch-based commands below.
+Apply a combined line budget of **15,000 lines** across all source material (diff, file contents, or both).
 
-For a **directory** source, gather all text files in the specified directory (skip binaries). There is no diff — pass the full contents of each file to reviewers. If the directory does not exist, report the error and stop. Apply the same 10,000-line budget to the total file contents: if the total exceeds 10,000 lines, print the warning below, then pause and ask the user whether to continue with the first 10,000 lines or stop. Skip the branch-based commands below.
+**`commit` source** — all diff and file data comes from `git show <sha>`. Count the output lines via `wc -l`. If the total exceeds 15,000 lines, trigger the budget warning. Skip the branch-based commands below.
 
-Warning to print when directory file contents exceed 10,000 lines:
+**`directory` source** — gather all text files in the specified directory (skip binaries). There is no diff — pass the full contents of each file to reviewers. If the directory does not exist, report the error and stop. Count total lines across all gathered files. If the total exceeds 15,000 lines, trigger the budget warning. Skip the branch-based commands below.
 
-```
----
-
-These file contents exceed 10,000 lines. A review of this scope risks missing issues and producing low-quality findings.
-
-Recommendation:
-1. Identify files that can be excluded from the review and narrow the directory path.
-2. Run the review against a specific subdirectory: `/agent-code-review directory <path>`
-
-Continue with the partial review (first 10,000 lines only), or stop here to
-narrow the scope?
-
----
-```
-
-For all other sources, gather:
+**All other sources** — gather:
 
 - Changed file list: `git diff <default>...<branch> --name-only` (or `gh pr diff <number> --name-only` for PRs)
 - Commit messages: `git log -10 <default>..<branch>` (or `gh pr view <number> --json commits` for PRs)
 
 If the diff is empty, report "No changes detected" and stop.
 
-Apply a combined line budget of **10,000 lines** across the diff and full file reads.
+Count diff lines via `wc -l` on the diff output. If the diff alone exceeds 15,000 lines, trigger the budget warning immediately.
 
-Evaluate:
+If the diff fits within budget, estimate total file sizes from `git diff --stat` output. If the estimated diff + file lines ≤ 15,000, read all changed files in full. If the estimated total exceeds 15,000, trigger the budget warning.
 
-- **Diff alone exceeds 10,000 lines** — do not proceed to Phase 3. Print the warning below, then pause and ask the user whether to continue or stop.
-- **Diff fits within budget** — count the total lines across all changed files. If diff + file lines ≤ 10,000, read all files in full. If the combined total exceeds 10,000, skip full file reads and provide the diff only — note this for reviewers, then proceed to Phase 3.
+**Budget warning** — use `AskUserQuestion` before proceeding. Present the line count and offer:
 
-Warning to print when the diff alone exceeds 10,000 lines:
+1. Continue with the first 15,000 lines (truncated review)
+2. Stop and narrow the scope
 
-```
----
+Include source-specific advice: for directory sources, suggest narrowing the directory path; for commit sources, suggest reviewing a smaller commit; for diff sources, suggest isolating generated files in a separate commit or reviewing a single commit.
 
-This diff exceeds 10,000 lines. A review of this scope risks missing issues and producing low-quality findings.
-
-Recommendation:
-1. Identify files that can be excluded from the review (e.g. generated files) and isolate them in a separate commit.
-2. Prepare a single commit containing only the essential code changes.
-3. Run the review against that commit: `/agent-code-review commit <sha>`
-
-Continue with the partial review (first 10,000 lines only), or stop here to
-reorganise your commits?
-
----
-```
-
-If the user chooses to **stop**, end the task without proceeding to Phase 3.
-
-If the user chooses to **continue**, keep the first 10,000 lines, discard the rest, and note the truncation for reviewers before proceeding.
+If the user chooses to stop, end the task. If the user chooses to continue, keep the first 15,000 lines, discard the rest, and note the truncation for reviewers.
 
 ### Phase 3 — Create review team
 
-Create the team with a unique name by appending a short random suffix (e.g., `code-review-a3f9`) via `TeamCreate`. Spawn four reviewers via the Task tool (`subagent_type: "general-purpose"`, `model: "sonnet"`), passing the team name. Each reviewer receives the available source material (diff or file contents), file list, commit context where applicable, and any additional instructions.
+Generate a random 8-digit hex suffix (e.g., `a3f9b2c1`) using a shell command: `openssl rand -hex 4 2>/dev/null || date +%s | sha256sum | head -c 8`. Create the team via `TeamCreate` with name `agent-code-review-{suffix}`. Spawn four reviewers via the Task tool (`subagent_type: "general-purpose"`, `model: "sonnet"`), passing the team name. Each reviewer receives the available source material (diff or file contents), file list, commit context where applicable, and any additional instructions.
 
 Three reviewers receive specialisations chosen by the system based on the code under review. The fourth is the **sceptic** — it challenges assumptions, questions necessity, identifies what the other reviewers missed, and suggests simpler alternatives.
 
-Reviewers report findings with severity (Critical/High/Moderate/Minor), file and line reference, description, and suggested fix. They must also explicitly note areas they reviewed and found correct, stating what they checked and why it needs no changes.
+Reviewers report findings with severity (Critical/High/Moderate/Minor), file and line reference, description, and suggested fix. They must also explicitly note areas they reviewed and found correct, stating what they checked and why it needs no changes. Prefix findings that require user input with `[Question]` within their severity group. These drive the interview phase.
+
+Tag as `[Question]` when the finding depends on information not present in the codebase — business requirements, deployment constraints, or intentional design trade-offs. Do not tag findings with clear, codebase-derivable fixes.
+
+- `[Question]` — "The error handler silently swallows exceptions. Is this intentional for this endpoint?" (requires domain knowledge unavailable in the codebase)
+- Not `[Question]` — "The error handler silently swallows exceptions. Add logging and re-throw." (actionable without user input)
 
 ### Phase 4 — Collect reviews
 
@@ -119,21 +94,24 @@ Wait for all four reviewers to respond via the team messaging system. If a revie
 Consolidate all reviewer findings into a single severity-grouped report. Apply these rules:
 
 - Deduplicate: if multiple reviewers flagged the same issue, merge into one finding. When merging, use the highest severity.
+- Preserve `[Question]` prefixes during deduplication and consolidation. A merged finding retains the prefix if any constituent finding had it.
 - No per-reviewer attribution. The developer does not need to know which agent found what.
 - Omit sections that have no findings, including "Approved without changes".
-- No summary section, no recommendation line.
+- No findings summary or recommendation line.
 
-Output the report between `---` separators:
+Output the report:
 
 ```
----
-
 # Agent code review report
 
-## Review scope
+## Summary
 
-Source: [description]
-Files changed: [count]
+Title: {concise title suitable for GitHub}
+Source: [current branch | pr #N | branch name | commit sha | directory path]
+
+[1-2 paragraphs: what the changes do, which areas of the codebase they affect, and key design decisions]
+
+**Tip:** start a new conversation before acting on this report.
 
 ## Reviewers
 
@@ -164,45 +142,63 @@ Files changed: [count]
 
 [areas/aspects reviewed by one or more reviewers and found correct — aggregate all positive assessments]
 
----
+## Clarifications [omit if no interview]
+
+[User responses from interview]
 ```
 
-Copy the report to the system clipboard silently. Write the report to a temp file and pipe it into the platform-specific command via Bash:
+### Phase 6 — Save report
 
-```bash
-REPORT_FILE=$(mktemp)
-cat > "$REPORT_FILE" << 'REPORTEOF'
-<paste the report text here>
-REPORTEOF
-OS=$(uname -s)
-case "$OS" in
-  MINGW*|MSYS*|CYGWIN*) clip < "$REPORT_FILE" ;;
-  Darwin)                pbcopy < "$REPORT_FILE" ;;
-  Linux)                 xclip -selection clipboard < "$REPORT_FILE" 2>/dev/null || xsel -b < "$REPORT_FILE" ;;
-esac
-rm -f "$REPORT_FILE"
-```
+Write the report to `.claude/reports/{yyyyMMdd}-{HHmm}-agent-code-review-{suffix}.md`,
+where `{yyyyMMdd}` and `{HHmm}` are local machine time (`date +%Y%m%d` and `date +%H%M`)
+and `{suffix}` is the same hex suffix used for the team name.
+Create the `.claude/reports/` directory if it does not exist.
 
-Replace `<paste the report text here>` with the full report text.
+If the report contains `[Question]`-prefixed findings, proceed to the interview phase after clean up.
+Otherwise the command ends after clean up.
 
-### Phase 6 — Clean up
+### Phase 7 — Clean up
+
+The team is deleted before the interview phase. The interview uses `AskUserQuestion` on the parent agent and does not require the team to be active.
 
 Send `shutdown_request` to all reviewers. Wait briefly for acknowledgements, then proceed to `TeamDelete` — do not block indefinitely on unresponsive reviewers.
 
+### Phase 8 — Interview
+
+This phase collects user answers and overwrites the saved report file with updated content. The file save is mandatory — without it, the report lacks interview answers.
+
+**Run the interview tool:**
+
+Use the `AskUserQuestion` tool to present questions interactively. Group questions by priority — blocking questions first, then deferrable. For each question, provide 2-4 answer options that help the user make an informed choice rather than composing an answer from scratch. Draw options from codebase evidence, trade-offs, or reasonable alternatives as appropriate.
+
+If there are more questions than the tool supports per call, batch them across multiple calls — blocking questions in the first batch.
+
+**Collect answers:**
+
+The tool returns the user's selections. The user may also provide free-text via the built-in "Other" option. If the user declines to answer a question, leave it unresolved. If all questions are unresolved, end the interview.
+
+**Update the report** — for each answered question:
+
+- **Findings**: prepend `[Resolved]` to the description and append the user's answer on a new line prefixed with `Answer:`. Do not delete the finding — it serves as audit trail.
+- **Clarifications section**: add the answered question and the user's response. If the section did not exist, create it.
+- Skipped questions: no changes.
+
+**Save updated report:**
+
+Overwrite the same file path used in the Save report phase. Output the updated report in full.
+
 ## Constraints
 
-- Do not ask follow-up questions after the report
-- The report is the final output — nothing follows, including clipboard operation feedback
+- Do not proceed to implementation unless the user explicitly approves — the review is advisory only
+- The command ends after the interview save (or after cleanup if no interview). The conversation may continue with other work.
+- After interview, the saved report file must be overwritten with updated content
 
 ## Error handling
 
-- If the PR URL format is invalid, report the expected format and stop
-- If the PR is not found, report the error and stop
-- If `pr`, `commit`, or `directory` is given without a second token, report the expected syntax and stop
-- If the branch is not found, report the error and stop
-- If the commit SHA is not found, report the error and stop
-- If the directory does not exist, report the error and stop
-- If the directory is empty, report "No files found" and stop
+- If a keyword (`pr`, `branch`, `commit`, `directory`) is given without a second token, report the expected syntax and stop
+- If the `pr` second token is not a valid number or URL, report the expected format and stop
+- If the PR, branch, or commit is not found, report the error and stop
+- If the directory does not exist or is empty, report the error and stop
 - If the diff is empty, report "No changes detected" and stop
-- If `git fetch` fails, report the error and stop
+- If `gh` or `git` commands fail, report the error and stop
 - If there are permission issues, report the error and stop

--- a/.claude/commands/agent-plan-validate.md
+++ b/.claude/commands/agent-plan-validate.md
@@ -3,34 +3,39 @@
 ## Usage
 
 - `/agent-plan-validate` — uses issue number from conversation context
-- `/agent-plan-validate <issue>` — validates plan from the specified issue number
-- `/agent-plan-validate <file>` — validates plan from a local file
-- Text after the issue/file argument is passed to all validators as additional instructions
+- `/agent-plan-validate <issue>` — validates the plan from the specified issue number (e.g., `85`)
+- `/agent-plan-validate <file1> <file2> ...` — validates the plan from local files
+- Text after the last valid file path or issue number is passed as additional instructions
 
 ## Context
 
-Use after plan creation and before implementation. Spawns a validation team to review the plan from multiple angles, verify assumptions against the codebase, and surface issues. The output is a structured validation report. For lighter single-agent validation, use `/plan-validate`.
+Use after plan creation and before implementation. 
+Reviews the plan against the codebase to verify assumptions and surface issues that are harder to spot in the planning session.
+Best run in a fresh session — the planning context is not loaded, so gaps and errors become visible. 
+The output is a structured validation report. 
+
+This is an agent team version of `/plan-validate`; it spawns a validation team to review from multiple angles.
 
 ## Task
 
 Eight phases executed in order.
 
-### Phase 1 — Load plan
+### Phase 1 — Load the plan
 
 Parse the arguments:
 
-- **File paths provided** — test each whitespace-delimited token as a file path in order. The first token that does not resolve to a readable file ends the file list — that token and everything after it is passed to all validators as additional instructions. Read each valid file and concatenate their contents as the plan text.
+- **File paths provided** — test each whitespace-delimited token as a file path in order. The first token that does not resolve to a readable file ends the file list — that token and everything after it is passed as additional instructions. Read each valid file and concatenate their contents as the plan text.
 - **Numeric token** — if the first token is not a valid file path but is numeric, treat it as a GitHub issue number. Fetch via:
 
 ```bash
-gh issue view <number> --json body,title --jq '.title + "\n\n" + .body'
+gh issue view <number> --json title,body,state,createdAt,comments
 ```
 
-Everything after the issue number is passed to all validators as additional instructions.
+Parse JSON output: present title, body, and comments chronologically with author and timestamp. Everything after the issue number is passed as additional instructions.
 
-- **No arguments** — look for an issue number in the conversation context (e.g., from a prior `/plan-read`). If found, fetch it using the command above. If not found, report this and stop.
+- **No arguments** — if the plan is already in the conversation (from a prior `/plan-read`), use it. Otherwise look for an issue number in conversation context and fetch it using the command above. If not found, report this and stop.
 
-If a file path resolves but is not readable, report the error and stop. If the fetched plan text is empty, report this and stop.
+If a file path resolves but is not readable, report the error and stop. If the plan text is empty, report this and stop.
 
 Store the plan text for distribution to agents.
 
@@ -49,9 +54,9 @@ Record which files were read — the report includes them in the Context files s
 
 ### Phase 3 — Create validation team
 
-Create the team via `TeamCreate` with a unique name by appending a short random suffix (e.g., `plan-validate-a3f9`).
+Generate a random 8-digit hex suffix (e.g., `a3f9b2c1`) using a shell command: `openssl rand -hex 4 2>/dev/null || date +%s | sha256sum | head -c 8`. Create the team via `TeamCreate` with name `agent-plan-validate-{suffix}`.
 
-Before spawning validators, extract a verification checklist from the plan: every modified type, interface, or function signature, and their consumers identified during Phase 2 exploration.
+Before spawning validators, extract a verification checklist from the plan: every modified type, interface, or function signature, and their consumers identified during codebase exploration.
 
 Spawn three validators (two specialists, one sceptic) via the Task tool (`subagent_type: "general-purpose"`, `model: "sonnet"`), passing the team name. Each validator receives: the plan text (verbatim), the context package, the verification checklist, their role description, any additional instructions from the user, and the validator instructions below.
 
@@ -85,18 +90,24 @@ Wait for all three validators to respond via the team messaging system. If a val
 
 Consolidate all validator findings into a single report. Apply these rules:
 
-- Deduplicate: if multiple validators flagged the same issue, merge into one finding. When merging, use the most critical assessment.
+- Deduplicate: if multiple validators flagged the same issue, merge into one finding. When merging, use the most critical assessment. Preserve `[Question]` prefixes — a merged finding retains the prefix if any constituent finding had it.
 - Cross-reference validator coverage against the verification checklist. List uncovered items in the "Not verified" subsection.
 - No per-validator attribution. The developer does not need to know which agent found what.
 - Omit sections that have no findings, including "Approved without changes".
-- No summary section, no recommendation line.
+- No findings summary or recommendation line.
 
-Output the report between `---` separators:
+Output the report:
 
 ```
----
-
 # Plan validation report
+
+## Instructions
+
+1. Read this report file in full
+2. Enter plan mode, address the findings, and update the plan
+3. Once approved, run `/plan-update` to push the revised plan to the GitHub issue
+
+Do not proceed with implementation until the user explicitly approves.
 
 ## Validators
 
@@ -132,29 +143,24 @@ Output the report between `---` separators:
 
 ## Clarifications [omit if no interview]
 
-[user responses from interview]
+[User responses from interview]
 
 ## Context files
 
 [Single deduplicated numbered list of all files read during validation — by the
-parent agent in Phase 2 and by validators. No grouping by source, no validator
+parent agent during exploration and by validators. No grouping by source, no validator
 attribution. Omit files listed in the plan but not found or not readable —
 note these separately.]
-
-# Next steps for the planning agent
-
-1. Enter plan mode, address the findings, and update the plan
-2. Once approved, run `/plan-update` to push the revised plan to the GitHub issue
-
-Do not proceed with implementation. Do not ask the user whether to proceed — just run `/plan-update`.
-
----
 ```
 
 ### Phase 6 — Save report
 
-Write the report to `.claude/reports/plan-validate-{date}-{id}.md`, where `{date}` is the current date in `YYYY-MM-DD` format and `{id}` is the same random suffix used for the team name (e.g., `plan-validate-2026-03-07-a3f9.md`).
+Write the report to `.claude/reports/{yyyyMMdd}-{HHmm}-agent-plan-validate-{suffix}.md`, 
+where `{yyyyMMdd}` and `{HHmm}` are local machine time (`date +%Y%m%d` and `date +%H%M`) and `{suffix}` is the same hex suffix used for the team name (e.g., `20260307-1423-agent-plan-validate-a3f9b2c1.md`).
 Create the `.claude/reports/` directory if it does not exist.
+
+If the report contains `[Question]`-prefixed findings, proceed to the interview phase after clean up.
+Otherwise the command ends after clean up.
 
 ### Phase 7 — Clean up
 
@@ -162,7 +168,7 @@ Send `shutdown_request` to all validators. Wait briefly for acknowledgements, th
 
 ### Phase 8 — Interview
 
-If the report contains no `[Question]`-prefixed findings, skip this phase. The command ends after Phase 7.
+This phase collects user answers and overwrites the saved report file with updated content. The file save is mandatory — without it, the report lacks interview answers.
 
 **Run the interview tool:**
 
@@ -182,13 +188,13 @@ The tool returns the user's selections. The user may also provide free-text via 
 
 **Save updated report:**
 
-Overwrite the same file path used in Phase 6. Output the updated report in full. This is the final output of the command.
+Overwrite the same file path used in the Save report phase. Output the updated report in full.
 
 ## Constraints
 
-- Do not ask follow-up questions after the report
-- The report (or updated report after interview) is the final output — nothing follows
-- Do not execute the next steps in the report — they are for the planning agent
+- Do not execute the report instructions — they are for the planning agent in a subsequent session
+- The saved report is the deliverable; the command ends after the final save
+- After interview, the saved report file must be overwritten with updated content
 
 ## Error handling
 
@@ -197,5 +203,5 @@ Overwrite the same file path used in Phase 6. Output the updated report in full.
 - If a file path resolves but is not readable, report the error and stop
 - If the plan text is empty, report this and stop
 - If `gh` or `git` commands fail, report the error and stop
-- If a validator fails or times out, note the missing validator in the report and proceed with available results
 - If there are permission issues, report them and stop
+- If a validator fails or times out, note the missing validator in the report and proceed with available results

--- a/.claude/commands/agent-pre-planner.md
+++ b/.claude/commands/agent-pre-planner.md
@@ -3,12 +3,15 @@
 ## Usage
 
 - `/agent-pre-planner` — uses the most recent actionable user message as the brief
+- `/agent-pre-planner <issue>` — uses the specified issue number (e.g., `85`)
 - `/agent-pre-planner <file1> <file2> ...` — reads files as the brief
-- Text after the last valid file path is passed to all analysts as additional instructions
+- Text after the last valid file path or issue number is passed to all analysts as additional instructions
 
 ## Context
 
-Use this before entering plan mode. It spawns an analysis team to explore the codebase from multiple angles, surface risks, correct assumptions, and identify opportunities. The output is a two-part report: an enhanced brief followed by a consolidated findings list.
+Use this before entering plan mode. 
+It spawns an analysis team to explore the codebase from multiple angles, surface risks, correct assumptions, and identify opportunities. 
+The output is a two-part report: an enhanced brief followed by a consolidated findings list.
 
 ## Task
 
@@ -19,6 +22,19 @@ Eight phases executed in order.
 Parse the arguments:
 
 - **File paths provided** — test each whitespace-delimited token as a file path in order. The first token that does not resolve to a readable file ends the file list — that token and everything after it is passed to all analysts as additional instructions. Read each valid file and concatenate their contents as the brief.
+- **Issue number** — if the first token is not a valid file path but is numeric, treat it
+  as a GitHub issue number. Fetch via:
+
+  ```bash
+  gh issue view <number> --json title,body,state,createdAt,comments
+  ```
+
+  Parse JSON output: present title, body, and comments chronologically with author and
+  timestamp. The issue title and body form the brief. Comments provide additional context
+  (handoff notes, revised decisions, discussion). Everything after the issue number token
+  is passed as additional instructions.
+
+  Only one issue number is supported per invocation. Subsequent numeric tokens are passed as additional instructions, not as issue numbers. To analyse multiple issues, run the command separately for each.
 - **No arguments** — identify the most recent user message in conversation context that describes an intention, suggestion, technical query, or implementation plan. Quote it verbatim as the brief.
 
 If no brief is found (no arguments and no actionable message in context), report this and stop. If a file path resolves but is not readable, report the error and stop.
@@ -38,7 +54,7 @@ Record which files were read — the report includes them in the Context files s
 
 ### Phase 3 — Create analysis team
 
-Create the team via `TeamCreate` with a unique name by appending a short random suffix (e.g., `planner-a3f9`). Spawn four analysts via the Task tool (`subagent_type: "general-purpose"`, `model: "opus"`), passing the team name. Analysts use `opus` rather than `sonnet` because pre-plan analysis involves open-ended codebase reasoning and hypothesis evaluation — tasks that benefit from a more capable model than code review.
+Generate a random 8-digit hex suffix (e.g., `a3f9b2c1`) using a shell command: `openssl rand -hex 4 2>/dev/null || date +%s | sha256sum | head -c 8`. Create the team via `TeamCreate` with name `agent-pre-planner-{suffix}`. Spawn four analysts via the Task tool (`subagent_type: "general-purpose"`, `model: "opus"`), passing the team name. Analysts use `opus` rather than `sonnet` because pre-plan analysis involves open-ended codebase reasoning and hypothesis evaluation — tasks that benefit from a more capable model than code review.
 
 Each analyst receives: the brief (verbatim), the context package, their specialisation, any additional instructions from the user, and the analyst instructions below.
 
@@ -73,7 +89,7 @@ Consolidation rules:
 
 - Deduplicate findings across analysts (prefer the most specific formulation)
 - No per-analyst attribution
-- No summary section, no recommendation line
+- No findings summary or recommendation line
 - Each finding has a category-prefixed identifier (C1 [high], C2 [low] for Correction; R1 [high], R2 [low] for Risk; Q1 [blocking], Q2 [deferrable] for Question; I1 [high], I2 [low] for Insight; O1 [high], O2 [low] for Opportunity; V1, V2 for Confirmed), description, and file:line references where applicable
 - Each finding carries a severity tag: `[high]` (materially affects the plan — wrong assumption, architectural risk, blocking dependency) or `[low]` (observational, informational, nice-to-know)
 - Each question carries a priority tag instead of a severity tag: `[blocking]` (must be resolved before planning) or `[deferrable]` (can be resolved during or after planning)
@@ -108,12 +124,21 @@ Output the report:
 ```
 # Pre-plan analysis
 
+## Summary
+
+Title: {concise title suitable for GitHub}
+Source: [conversation context | file paths | issue #N]
+
+[1-2 paragraphs: what the brief is about, which areas of the codebase are affected, and key constraints or goals]
+
+**Tip:** start a new conversation before acting on this report.
+
 ## Analysts
 
-1. [name] -- [specialisation]
-2. [name] -- [specialisation]
-3. [name] -- [specialisation]
-4. [name] -- [sceptic description]
+1. [name] — [specialisation]
+2. [name] — [specialisation]
+3. [name] — [specialisation]
+4. [name] — [sceptic description]
 
 ## Enhanced brief
 
@@ -125,7 +150,7 @@ The result is the user's brief as it would read with full knowledge of the codeb
 
 ### Open questions [omit if empty]
 
-[Questions that require user input before planning -- grouped by priority (blocking first,
+[Questions that require user input before planning — grouped by priority (blocking first,
 then deferrable). One per line. Full context in § Question below.]
 
 ### Workload split
@@ -138,40 +163,42 @@ When not splitting, state that a single plan is sufficient.]
 
 ### Correction [omit if empty]
 
-[Numbered findings -- each with severity tag, description, what was wrong, what is correct, and file:line evidence]
+[Numbered findings — each with severity tag, description, what was wrong, what is correct, and file:line evidence]
 
 ### Risk [omit if empty]
 
-[Numbered findings -- each with severity tag, description, and file:line references]
+[Numbered findings — each with severity tag, description, and file:line references]
 
 ### Question [omit if empty]
 
-[Numbered findings -- each with priority tag, ambiguities the codebase could not resolve]
+[Numbered findings — each with priority tag, ambiguities the codebase could not resolve]
 
 ### Insight [omit if empty]
 
-[Numbered findings -- each with severity tag, description, and file:line references]
+[Numbered findings — each with severity tag, description, and file:line references]
 
 ### Opportunity [omit if empty]
 
-[Numbered findings -- each with severity tag, description, and file:line references]
+[Numbered findings — each with severity tag, description, and file:line references]
 
 ### Confirmed [omit if empty]
 
-[Numbered findings -- each with what was verified and file:line evidence]
+[Numbered findings — each with what was verified and file:line evidence]
 
 ## Context files
 
-[Single deduplicated numbered list of all files read during analysis -- by the
-parent agent in Phase 2 and by analysts. No grouping by source, no analyst
-attribution. Omit files listed in the brief but not found or not readable --
+[Single deduplicated numbered list of all files read during analysis — by the
+parent agent during exploration and by analysts. No grouping by source, no analyst
+attribution. Omit files listed in the brief but not found or not readable —
 note these separately.]
 ```
 
 ### Phase 6 — Save report
 
-Write the report to `.claude/reports/pre-plan-{date}-{id}.md`, where `{date}` is the current date in `YYYY-MM-DD` format and `{id}` is the same random suffix used for the team name (e.g., `pre-plan-2026-02-16-a3f9.md`).
+Write the report to `.claude/reports/{yyyyMMdd}-{HHmm}-agent-pre-planner-{suffix}.md`, where `{yyyyMMdd}` and `{HHmm}` are local machine time (`date +%Y%m%d` and `date +%H%M`) and `{suffix}` is the same hex suffix used for the team name (e.g., `20260216-0945-agent-pre-planner-a3f9b2c1.md`).
 Create the `.claude/reports/` directory if it does not exist.
+
+If the report contains an `### Open questions` subsection with questions, proceed to the interview phase after clean up. Otherwise the command ends after clean up.
 
 ### Phase 7 — Clean up
 
@@ -179,7 +206,7 @@ Send `shutdown_request` to all analysts. Wait briefly for acknowledgements, then
 
 ### Phase 8 — Interview
 
-If the report has no `### Open questions` subsection or it is empty, skip this phase. The command ends after Phase 7.
+This phase collects user answers and overwrites the saved report file with updated content. The file save is mandatory — without it, the report lacks interview answers.
 
 **Run the interview tool:**
 
@@ -200,7 +227,12 @@ The tool returns the user's selections. The user may also provide free-text via 
 
 **Save updated report:**
 
-Overwrite the same file path used in Phase 6. Output the updated report in full. This is the final output of the command.
+Overwrite the same file path used in the Save report phase. Output the updated report in full.
+
+## Constraints
+
+- The saved report is the deliverable; the command ends after the final save
+- After interview, the saved report file must be overwritten with updated content
 
 ## Error handling
 
@@ -208,3 +240,5 @@ Overwrite the same file path used in Phase 6. Output the updated report in full.
 - If a file path resolves but is not readable, report the error and stop
 - If the repository is empty or no relevant files are found, report this and stop
 - If an analyst fails or times out, note the missing analyst in the report and proceed with available findings
+- If the issue does not exist, report the error and stop
+- If `gh` commands fail, report the error and stop

--- a/.claude/commands/agent-revisor.md
+++ b/.claude/commands/agent-revisor.md
@@ -5,11 +5,11 @@
 - `/agent-revisor` — revise tests and auto-discovered documentation (from manifest and CLAUDE.md files)
 - `/agent-revisor file1.md file2.md` — revise tests and the specified documentation files
 - `/agent-revisor ["file1.md", "file2.md"]` — JSON array format for documentation files
-- Text after the last valid file path (or after the JSON array) is passed to both agents as additional instructions
+- Text after the last valid file path (or after the JSON array) is passed to all agents as additional instructions
 
 ## Context
 
-Use after implementation is complete and before PR creation. Spawns a two-agent team to revise unit tests and documentation in parallel. Agents remain alive after reporting so the user can iterate.
+Use after implementation is complete and before PR creation. Spawns a three-agent team to revise unit tests and documentation in parallel. Agents remain alive after reporting so the user can iterate.
 
 ## Task
 
@@ -52,20 +52,20 @@ Assemble the following for the agent prompts:
 - Full diff (`git diff <default>...HEAD`)
 - Commit messages (`git log -10 <default>..HEAD --oneline`)
 - Documentation file list (for documentation-revisor only)
-- Additional instructions from Phase 1 (forwarded to both agents, if present)
+- Additional instructions from argument parsing (forwarded to all agents, if present)
 
 **Line budget**: Apply a 10,000-line cap to the diff. If the diff exceeds 10,000 lines, pause and ask the user whether to continue with the first 10,000 lines or stop. Agents process files individually (reading and editing one at a time), so individual file reads by agents are not counted against the budget — only the diff context passed in the initial prompt is capped.
 
-**Edge case — no documentation files**: If the merged documentation file list is empty (no arguments, no manifest, no CLAUDE.md files found), skip documentation-revisor. Report: "No documentation files to revise." Spawn unit-test-revisor only.
+**Edge case — no documentation files**: If the merged documentation file list is empty (no arguments, no manifest, no CLAUDE.md files found), skip documentation-revisor. Report: "No documentation files to revise." Spawn unit-test-revisor and a11y-revisor only (a11y-revisor subject to its own `.tsx` precondition below).
 
 **Edge case — nothing to revise**: If documentation files are empty AND all touched files have non-testable extensions (e.g. `.md`, `.json`, `.yaml`, `.lock`, `.svg`, `.png` — configuration files, static assets, and markup with no executable logic), report: "Nothing to revise — no testable source files and no documentation files." and stop without spawning the team.
 
 ### Phase 3 — Create revision team
 
-`TeamCreate` with unique name (e.g., `revisor-a3f9`). Spawn via Task tool:
+Generate a random 8-digit hex suffix (e.g., `a3f9b2c1`) using a shell command: `openssl rand -hex 4 2>/dev/null || date +%s | sha256sum | head -c 8`. Create the team via `TeamCreate` with name `agent-revisor-{suffix}`. Spawn via Task tool:
 
 - `subagent_type: "general-purpose"`
-- `model: "sonnet"` for both agents
+- `model: "sonnet"` for all agents
 - Pass team name to each
 
 **unit-test-revisor** receives:
@@ -105,9 +105,22 @@ Assemble the following for the agent prompts:
   4. Do not commit or push code.
   5. Send a summary to the team lead via `SendMessage`: files revised (path + what changed), files skipped (path + reason). Include the change manifest in the summary.
 
+**a11y-revisor** receives (only if touched file list filtered to `*.tsx` is non-empty; otherwise skip and report "No `.tsx` files to review."):
+- Touched file list filtered to `*.tsx` only, full diff, commit messages, plan summary (if available), additional instructions (if any)
+- Instructions:
+  1. Scan each touched `.tsx` file for accessibility issues.
+  2. Check ARIA attributes — verify interactive elements have appropriate roles, labels, and states.
+  3. Check keyboard navigation — verify focusable elements have keyboard handlers, tab order is logical, focus traps exist where needed (modals, drawers).
+  4. Check semantic HTML — verify correct element usage (button vs div with onClick, nav, main, aside, section with headings).
+  5. Check focus management — verify focus moves appropriately on navigation, modal open/close, dynamic content changes.
+  6. Check colour contrast considerations — flag hardcoded colour values without contrast verification, verify text meets WCAG contrast requirements where determinable.
+  7. Edit files to fix issues found. Add missing ARIA attributes, fix keyboard handlers, improve semantic markup. After edits, verify TypeScript compilation — check `package.json` scripts for a type-check command (e.g., `ts:quick`, `typecheck`, `type-check`) and run it; if none exists, fall back to `npx tsc --noEmit`. If your changes introduce type errors, revert the offending edit and record it under "files skipped" in the summary.
+  8. Do not commit or push code.
+  9. Send summary to team lead via `SendMessage`: files revised (path + what changed), files skipped (path + reason).
+
 ### Phase 4 — Collect results
 
-Wait for both agents (or one, if documentation-revisor was skipped) to send their summaries via `SendMessage`. Messages are delivered automatically when each agent finishes its turn. If an agent goes idle after sending its summary, that is normal — the summary has been received. If an agent fails or does not respond within the platform's default task timeout, proceed with available results and note the missing agent in the output.
+Wait for all agents (unit-test-revisor, a11y-revisor, and documentation-revisor if not skipped) to send their summaries via `SendMessage`. Messages are delivered automatically when each agent finishes its turn. If an agent goes idle after sending its summary, that is normal — the summary has been received. If an agent fails or does not respond within the platform's default task timeout, proceed with available results and note the missing agent in the output.
 
 ### Phase 5 — Output summary
 
@@ -121,6 +134,10 @@ Consolidate agent summaries into brief output. No report file saved. No clipboar
 ## Unit tests
 
 [summary from unit-test-revisor]
+
+## Accessibility
+
+[summary from a11y-revisor, or "Skipped — no `.tsx` files to review"]
 
 ## Documentation
 

--- a/.claude/commands/plan-validate.md
+++ b/.claude/commands/plan-validate.md
@@ -2,24 +2,40 @@
 
 ## Usage
 
-- `/plan-validate` - Uses the issue number from conversation context
-- `/plan-validate <issue>` - Validates the plan from the specified issue (e.g., `85`)
+- `/plan-validate` — uses issue number from conversation context
+- `/plan-validate <issue>` — validates the plan from the specified issue number (e.g., `85`)
+- `/plan-validate <file1> <file2> ...` — validates the plan from local files
+- Text after the last valid file path or issue number is passed as additional instructions
 
 ## Context
 
-Use this in session 2. A fresh session provides perspective the planning session lacks — assumptions become visible, gaps surface, and ambiguities clarify. This step catches issues before code is written.
+Use after plan creation and before implementation. 
+Reviews the plan against the codebase to verify assumptions and surface issues that are harder to spot in the planning session.
+Best run in a fresh session — the planning context is not loaded, so gaps and errors become visible. 
+The output is a structured validation report. 
+
+This is a single-agent version of `/agent-plan-validate`.
 
 ## Task
 
-Execute these phases in order.
+Five phases executed in order.
 
 ### Phase 1 — Load the plan
 
-If the plan is already loaded in the conversation (via a prior `/plan-read`), skip this step. Otherwise, invoke `/plan-read` via the Skill tool to fetch the issue:
+Parse the arguments:
 
-Use the Skill tool with `skill: "plan-read"` and pass the issue number as `args`.
+- **File paths provided** — test each whitespace-delimited token as a file path in order. The first token that does not resolve to a readable file ends the file list — that token and everything after it is passed as additional instructions. Read each valid file and concatenate their contents as the plan text.
+- **Numeric token** — if the first token is not a valid file path but is numeric, treat it as a GitHub issue number. Fetch via:
 
-This keeps issue-fetching logic in one place.
+```bash
+gh issue view <number> --json title,body,state,createdAt,comments
+```
+
+Parse JSON output: present title, body, and comments chronologically with author and timestamp. Everything after the issue number is passed as additional instructions.
+
+- **No arguments** — if the plan is already in the conversation (from a prior `/plan-read`), use it. Otherwise look for an issue number in conversation context and fetch it using the command above. If not found, report this and stop.
+
+If a file path resolves but is not readable, report the error and stop. If the plan text is empty, report this and stop.
 
 ### Phase 2 — Validate
 
@@ -32,66 +48,97 @@ Review the plan against these criteria:
 
 Explore the codebase to verify assumptions. Check that referenced files and patterns exist as described. Identify related code that might be affected.
 
-### Phase 3 — Interview
+Prefix findings that require user input with `[Question]`. These drive the interview phase.
 
-If findings require user input, ask focused questions using AskUserQuestion. Wait for responses. Incorporate answers into the report — inline with findings or as a separate Clarifications section, at your discretion.
+### Phase 3 — Generate report
 
-If no clarifications are needed, skip this phase.
-
-### Phase 4 — Report
-
-Output the structured report between `---` separators. This is the last text you output — nothing follows the closing separator.
+Assemble the report content internally. The assembled report text must not appear in conversation until the save phase outputs it.
 
 ```
----
-
 # Plan validation report
+
+## Instructions
+
+1. Read this report file in full
+2. Enter plan mode, address the findings, and update the plan
+3. Once approved, run `/plan-update` to push the revised plan to the GitHub issue
+
+Do not proceed with implementation until the user explicitly approves.
 
 ## Findings
 
-[Validation results organised by category]
+### Clarity [omit if empty]
 
-## Clarifications
+[findings — each with description and file:line references]
 
-[User responses from interview, if any. Omit section if none needed.]
+### Accuracy [omit if empty]
 
-# Next steps for the planning agent
+[findings — each with what was claimed, what was found, and file:line evidence]
 
-1. Enter plan mode, address the findings, and update the plan
-2. Once approved, run `/plan-update` to push the revised plan to the GitHub issue
+### Completeness [omit if empty]
 
-Do not proceed with implementation. Do not ask the user whether to proceed — just run `/plan-update`.
+[findings — each with description and file:line references]
 
----
+### Feasibility [omit if empty]
+
+[findings — each with description and file:line references]
+
+### Approved without changes [omit if empty]
+
+[areas reviewed and found correct — stating what was checked and why it needs no changes]
+
+## Clarifications [omit if no interview]
+
+[User responses from interview]
 ```
 
-### Clipboard copy
+### Phase 4 — Save and output report
 
-After outputting the report, copy everything between and including the `---` separators to the system clipboard.
+Generate an 8-digit hex suffix (`openssl rand -hex 4 2>/dev/null || date +%s | sha256sum | head -c 8`). Write the report to
+`.claude/reports/{yyyyMMdd}-{HHmm}-plan-validate-{suffix}.md`, where `{yyyyMMdd}` and
+`{HHmm}` are local machine time (`date +%Y%m%d` and `date +%H%M`).
+Create the `.claude/reports/` directory if it does not exist.
 
-Detect the platform and run the appropriate command silently via Bash:
+Output the report in full.
 
-```bash
-OS=$(uname -s)
-case "$OS" in
-  MINGW*|MSYS*|CYGWIN*) cat <<'EOF' | clip ;;
-  Darwin)                cat <<'EOF' | pbcopy ;;
-  Linux)                 cat <<'EOF' | xclip -selection clipboard 2>/dev/null || cat <<'EOF' | xsel -b ;;
-esac
-<paste the report text here>
-EOF
-```
+If the report contains `[Question]`-prefixed findings, proceed to the interview phase.
+Otherwise the command ends here.
 
-Replace `<paste the report text here>` with the full report text. The heredoc preserves formatting and special characters.
+### Phase 5 — Interview
+
+This phase collects user answers and overwrites the saved report file with updated content. The file save is mandatory — without it, the report lacks interview answers.
+
+**Run the interview tool:**
+
+Use the `AskUserQuestion` tool to present questions interactively. Group questions by priority — blocking questions first, then deferrable. For each question, provide 2-4 answer options that help the user make an informed choice rather than composing an answer from scratch. Draw options from codebase evidence, trade-offs, or reasonable alternatives as appropriate.
+
+If there are more questions than the tool supports per call, batch them across multiple calls — blocking questions in the first batch.
+
+**Collect answers:**
+
+The tool returns the user's selections. The user may also provide free-text via the built-in "Other" option. If the user declines to answer a question, leave it unresolved. If all questions are unresolved, end the interview.
+
+**Update the report** — for each answered question:
+
+- **Findings**: prepend `[Resolved]` to the description and append the user's answer on a new line prefixed with `Answer:`. Do not delete the finding — it serves as audit trail.
+- **Clarifications section**: add the answered question and the user's response. If the section did not exist, create it.
+- Skipped questions: no changes.
+
+**Save updated report:**
+
+Overwrite the same file path used in the Save report phase. Output the updated report in full.
 
 ## Constraints
 
-- Do not ask follow-up questions after the report ("Should we proceed?", "What would you like to do next?")
-- The report is the absolute last text output
-- The clipboard command runs silently — no output after the report
+- Do not execute the report instructions — they are for the planning agent in a subsequent session
+- The saved report is the deliverable; the command ends after the final save
+- After interview, the saved report file must be overwritten with updated content
 
 ## Error handling
 
-- If issue number cannot be determined, report this clearly and stop
-- If issue does not exist, report the error
-- If there are permission issues, report them
+- If no issue number can be determined and no file is provided, report this clearly and stop
+- If the issue does not exist, report the error and stop
+- If a file path resolves but is not readable, report the error and stop
+- If the plan text is empty, report this and stop
+- If `gh` or `git` commands fail, report the error and stop
+- If there are permission issues, report them and stop

--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -18,7 +18,7 @@ Commands live in `.claude/commands/`. Most commands execute directly. Commands t
 
 **/plan-read** — loads plan and handoffs from an issue to continue work
 
-**/plan-validate** — loads the plan (invokes `/plan-read`), validates against the codebase, interviews the engineer if needed, and outputs a structured report for the planning agent
+**/plan-validate** — validates the plan against the codebase, interviews the engineer if findings need clarification, and saves a structured report for the planning agent
 
 **/plan-update** — updates a GitHub issue with revised plan content from the conversation
 
@@ -34,7 +34,7 @@ Commands live in `.claude/commands/`. Most commands execute directly. Commands t
 
 **/agent-pre-planner** — runs a pre-plan analysis: identifies confirmed findings, risks, and open questions before implementation begins
 
-**/agent-revisor** — revises unit tests and documentation on the current branch
+**/agent-revisor** — revises unit tests, accessibility, and documentation on the current branch
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Design the implementation and publish it.
 
 A fresh session provides perspective the planning session lacks. Assumptions become visible, gaps surface, and ambiguities clarify.
 
-1. `/plan-validate <issue>` — loads the plan (chains `/plan-read` internally), validates against the codebase, and interviews you if findings need clarification
+1. `/plan-validate <issue>` — loads the plan, validates against the codebase, and interviews you if findings need clarification
 2. The command outputs a structured report with an instruction header, findings, and any clarifications
-3. The report is copied to the clipboard automatically
+3. The report is saved to `.claude/reports/`
 
 ## Revise
 
-Return to the planning session and paste the validation report. The report's instruction header tells the planning agent to:
+Return to the planning session and point it to the validation report file. The report's instruction header tells the planning agent to:
 
 1. Enter plan mode and address the findings
 2. Exit plan mode


### PR DESCRIPTION
## Overview

Standardise and extend the agent command specifications. Key changes across all five command files:

- Consistent 8-digit hex suffix generation for team names and report filenames
- Unified report file naming: `{yyyyMMdd}-{HHmm}-{command}-{suffix}.md` saved to `.claude/reports/`
- `[Question]`/interview phase added to `agent-code-review` (now 8 phases, up from 6)
- `plan-validate` is now self-contained — fetches issues directly instead of delegating to `/plan-read`, supports multi-file input, saves reports to disk instead of clipboard
- `agent-pre-planner` accepts issue numbers as input
- `agent-revisor` expanded from two agents to three with the addition of an a11y-revisor for `.tsx` accessibility checks
- Line budget increased from 10,000 to 15,000 in `agent-code-review`
- `branch` keyword added to `agent-code-review` scope resolution; bare branch names and bare SHAs removed in favour of explicit keywords
- Budget warnings now use `AskUserQuestion` instead of inline text blocks

Updates `commands.md` and `README.md` to reflect the new behaviour.

## Technical details

- `agent-code-review`: consolidated PR URL handling into the `pr` keyword (accepts both number and URL), added `branch` keyword, replaced inline budget warning text with `AskUserQuestion` flow, added Phase 7 (clean up) and Phase 8 (interview), report structure gains Summary and Clarifications sections
- `agent-plan-validate`: multi-file input support, richer issue fetching (includes comments, state, timestamps), Instructions section moved inside the report template, `[Question]` prefix preservation during deduplication
- `agent-pre-planner`: issue number parsing with full JSON output, Summary section added to report template, explicit Constraints section added
- `agent-revisor`: a11y-revisor spawned conditionally when `.tsx` files are touched, checks ARIA attributes, keyboard navigation, semantic HTML, focus management, and colour contrast; Accessibility section added to output summary
- `plan-validate`: restructured from 4 phases to 5, self-contained issue fetching replaces `/plan-read` delegation, interview phase uses `AskUserQuestion`, saves report to `.claude/reports/` instead of clipboard copy

## Plan reference

No linked plan — this is a specification sync.